### PR TITLE
Fix usage of booleans, require and nil

### DIFF
--- a/hytest.hy
+++ b/hytest.hy
@@ -73,8 +73,8 @@
 (defn test-is [lhs rhs] (cmp-base `is lhs rhs "%s is not %s"))
 (defn test-is-not [lhs rhs] (cmp-base `is-not lhs rhs "%s is %s"))
 
-(defn test-is-nil [x] (test-is x `nil))
-(defn test-is-not-nil [x] (test-is-not x `nil))
+(defn test-is-nil [x] (test-is x `None))
+(defn test-is-not-nil [x] (test-is-not x `None))
 
 (defn almost-base [op] `(fn [lhs rhs] (~op (round (- lhs rhs) 7) 0)))
 (defn test-almost-eq [lhs rhs] (cmp-base (almost-base `=) lhs rhs
@@ -94,8 +94,8 @@
 (defn test-items-ne [lhs rhs] (cmp-base (items-base `!=) lhs rhs
                                "items in %s are equal to items in %s"))
 
-(defn test-true [x] (cmp-base `(fn [x _] x) x `nil "%s is not true"))
-(defn test-not [x] (cmp-base `(fn [x _] (not x)) x `nil "%s is not true"))
+(defn test-true [x] (cmp-base `(fn [x _] x) x `None "%s is not true"))
+(defn test-not [x] (cmp-base `(fn [x _] (not x)) x `None "%s is not true"))
 
 (defn test-in [x sq] (cmp-base `in x sq "item %s not in sequence %s"))
 (defn test-not-in [x sq] (cmp-base `not-in x sq "item %s is in sequence %s"))
@@ -204,7 +204,7 @@
 
 (defn get-setup-and-teardown [body]
   (setv body (list body))
-  (defmacro get-f2 [x] `(if (and body (get body 0)) (get (get body 0) 0) nil))
+  (defmacro get-f2 [x] `(if (and body (get body 0)) (get (get body 0) 0) None))
   (if (= (get-f2 body) (HySymbol "test_setup"))
     (setv setup (cut (.pop body 0) 1))
     (setv setup (HyExpression [])))
@@ -305,7 +305,7 @@
       (starstr (% "CAPTURED STDERR: %s: " tst))
       (print err))
     (st.pop 0))
-  (while true
+  (while True
     (try
       (print-bufs 2)
       (except [ValueError] (break))))

--- a/test_hytest.hy
+++ b/test_hytest.hy
@@ -1,4 +1,4 @@
-(require hytest)
+(require [hytest [*]])
 (import [hytest [find-tests FailException]]
         [os [getcwd makedirs path]]
         [shutil [rmtree]]
@@ -21,7 +21,7 @@
   (test raises-msg "failthis" (fail-test "failthis")))
 
 (test-set-fails test-fails2
-  (assert false))
+  (assert False))
 
 (test-set test-cmp
   (test = 1 1)
@@ -41,10 +41,10 @@
   (test raises-exc [FailException] (test is-not obj obj)))
 
 (test-set test-nil
-  (test is-nil nil)
+  (test is-nil None)
   (test is-not-nil 0)
   (test raises-exc [FailException] (test is-nil 0))
-  (test raises-exc [FailException] (test is-not-nil nil)))
+  (test raises-exc [FailException] (test is-not-nil None)))
 
 (test-set test-almost
   (test aeq 1.00000001 1)
@@ -71,19 +71,19 @@
   (test raises-exc [FailException] (test not-in 1 [1 2 3])))
 
 (test-set test-raises
-  (test raises (assert false))
-  (test raises-exc [AssertionError] (assert false))
+  (test raises (assert False))
+  (test raises-exc [AssertionError] (assert False))
   (test raises-msg "abc" (raise (ValueError "1abc2")))
-  (test not-raises (assert true))
-  (test not-raises-exc [AssertionError] (assert true))
+  (test not-raises (assert True))
+  (test not-raises-exc [AssertionError] (assert True))
   (test not-raises-msg "abc" (raise (ValueError "1ab2c"))))
 
 (test-set test-boolcmp
-  (test true 1)
-  (test false 0)
+  (test True 1)
+  (test False 0)
   (test not 0)
-  (test raises-exc [FailException] (test true 0))
-  (test raises-exc [FailException] (test false 1))
+  (test raises-exc [FailException] (test True 0))
+  (test raises-exc [FailException] (test False 1))
   (test raises-exc [FailException] (test not 1)))
 
 (def x 1)


### PR DESCRIPTION
Recently hylang changed the way how booleans, require and nil are
used. This change makes hytest compatible with those changes.