### PR TITLE
Remove `let` and import from hy.models

### DIFF
--- a/hytest.hy
+++ b/hytest.hy
@@ -1,8 +1,5 @@
 (import [hy.importer [import-file-to-module]]
-        [hy.models.string [HyString]]
-        [hy.models.integer [HyInteger]]
-        [hy.models.symbol [HySymbol]]
-        [hy.models.expression [HyExpression]]
+        [hy.models [HyExpression HyInteger HyString HySymbol]]
         [collections [OrderedDict]]
         [os [walk getcwd path]]
         traceback

--- a/test_hytest.hy
+++ b/test_hytest.hy
@@ -96,16 +96,16 @@
   (.close (open (apply path.join parts) "a")))
 
 (test-set test-find-tests
-  (let [root (mkdtemp)]
-    (try
-     (do (makedirs (path.join root "a" "b" "c"))
-         (touch root "test_root.hy")
-         (touch root "a" "test_a.hy")
-         (touch root "a" "b" "test_b.hy")
-         (touch root "a" "b" "c" "test_c.hy")
-         (test = (find-tests root)
-               [(path.join root "test_root.hy")
-                (path.join root "a" "test_a.hy")
-                (path.join root "a" "b" "test_b.hy")
-                (path.join root "a" "b" "c" "test_c.hy")]))
-     (finally (rmtree root)))))
+  (setv root (mkdtemp))
+  (try
+   (do (makedirs (path.join root "a" "b" "c"))
+       (touch root "test_root.hy")
+       (touch root "a" "test_a.hy")
+       (touch root "a" "b" "test_b.hy")
+       (touch root "a" "b" "c" "test_c.hy")
+       (test = (find-tests root)
+             [(path.join root "test_root.hy")
+              (path.join root "a" "test_a.hy")
+              (path.join root "a" "b" "test_b.hy")
+              (path.join root "a" "b" "c" "test_c.hy")]))
+   (finally (rmtree root))))


### PR DESCRIPTION
Hy removed the `let` form recently and moved classes like HyString,
HySymbol, etc to the hy.models namespace. This patch makes hytest
compatible with the latest version of Hy.